### PR TITLE
Migration/version windows

### DIFF
--- a/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/BabylonReactNative.vcxproj
+++ b/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/BabylonReactNative.vcxproj
@@ -165,6 +165,7 @@
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <!-- Include project headers when building in the repo -->
       <AdditionalIncludeDirectories Condition="Exists('$(BabylonReactNativeDir)shared')">$(BabylonReactNativeDir)shared;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories Condition="Exists('$(BabylonNativeIOSAndroidProjDir)shared')">$(BabylonNativeIOSAndroidProjDir)shared;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
@@ -223,6 +224,7 @@
     <ClCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories Condition="Exists('$(BabylonReactNativeDir)shared')">$(BabylonReactNativeDir)shared;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories Condition="Exists('$(BabylonNativeIOSAndroidProjDir)shared')">$(BabylonNativeIOSAndroidProjDir)shared;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>


### PR DESCRIPTION
Update "Modules\@babylonjs\react-native-windows\windows\BabylonReactNative\BabylonReactNative.vcxproj" to properly handle AditionalIncludeDirectories from both the repo build as well as when it is been used in a npm package.

