### PR TITLE
Prevent partial outputs when unzipping Babylon Native sources on macOS

### DIFF
--- a/Package/gulpfile.js
+++ b/Package/gulpfile.js
@@ -260,9 +260,8 @@ async function downloadZip(url, dest) {
 }
 
 async function unzipFile(zipPath, destDir) {
-  await fs.createReadStream(zipPath)
-    .pipe(unzipper.Extract({ path: destDir }))
-    .promise();
+  const dir = await unzipper.Open.file(zipPath);
+  await dir.extract({ path: destDir });
 }
 
 function deleteFile(filePath) {


### PR DESCRIPTION
When you build the project for the first time, `setup_dev.js` fails on macOS due to missing files after unzipping:

<img width="1068" height="165" alt="image" src="https://github.com/user-attachments/assets/bd73f986-80c6-4f1c-a144-0b47632dac49" /><br/>

**Problem**
Files like `Plugins/NativeTracing/CMakeLists.txt`, `Polyfills` folder, and other files under `Modules/@babylonjs/react-native/shared/BabylonNative/Repo` are missing on disk after unzip step. 

With `unzipper.Extract({ path: destDir, verbose: true })` enabled, those entries are are logged as "inflating" but never appear on disk. Probably, on macOS, using the streaming API `createReadStream`  can lead to a premature close and silently skipped entries.

**Fix**
Read the central directory first and extract entries deterministically, which prevents early stream closure and ensures all files are written.

---

**System info**
macOS: Sequoia 15.6.1
Node: 22.13.0

---
**Addtional notes**
- The issue doesn't reproduce on Windows.
- Added `CedricGuillemet/BabylonReactNative-1` as remote on my fork, checked out a branch from `NewNPM` and opened the pull request.
