### PR TITLE
Remove existing Repo folder before renaming in buildBabylonNativeSourceTree

### DIFF
--- a/Package/gulpfile.js
+++ b/Package/gulpfile.js
@@ -361,6 +361,11 @@ const buildBabylonNativeSourceTree = async () => {
   writeCMakeListsFile(CMAKE_LISTS_PATH);
 
   console.log('Renaming BabylonNative-xxx folder ...');
+  const repoPath = `${TARGET_DIR}/Repo`;
+  if (fs.existsSync(repoPath)) {
+    console.log('Removing existing Repo folder before rename...');
+    deleteFolderRecursive(repoPath);
+  }
   await fs.rename(`${TARGET_DIR}/BabylonNative-${COMMIT_ID}`, `${TARGET_DIR}/Repo`, (err) => {
     if (err) throw err;
     console.log('Rename complete!');


### PR DESCRIPTION
Added a defensive cleanup in gulpfile.js so any existing Repo folder is deleted before renaming the freshly downloaded source tree, preventing Windows EPERM failures during buildBabylonNativeSourceTree